### PR TITLE
support paths (external names) with dots

### DIFF
--- a/lib/git_external.rb
+++ b/lib/git_external.rb
@@ -26,7 +26,7 @@ class GitExternal
   def parse_configuration(lines)
     config = {}
     lines.each do |line|
-      if line =~ /^external\.([^\.]+)\.([^=]+)=(.*)$/
+      if line =~ /^external\.(.*)\.(.*)=(.*)$/
         config[$1.chomp] ||= {}
         config[$1.chomp][$2.chomp] = $3.chomp
       end


### PR DESCRIPTION
e.g. org.example.module
